### PR TITLE
bb-editing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -778,6 +778,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@fortawesome/fontawesome-free": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.8.1.tgz",
+      "integrity": "sha512-GJtx6e55qLEOy2gPOsok2lohjpdWNGrYGtQx0FFT/++K4SYx+Z8LlPHdQBaFzKEwH5IbBB4fNgb//uyZjgYXoA=="
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "webpack-dev-server": "^3.3.1"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.8.1",
     "axios": "^0.18.0",
     "bootstrap": "^4.3.1",
     "jquery": "^3.4.0",

--- a/src/index.html
+++ b/src/index.html
@@ -16,7 +16,7 @@
   </nav>
   <div class="sizeControl container d-flex justify-content-center align-items-center col-12">
     <input type="checkbox" id="increaseSize" style="font-weight:bold">TextSizeIncrease</input>
-    <input type="checkbox" id="darkMode" name="dark_light" onclick="toggleDarkLight" title="Toggle dark/light mode">🌛Dark Mode</input>
+    <input type="checkbox" id="toggleDark" name="dark_light" onclick="toggleDarkLight" title="Toggle dark/light mode">🌛Dark Mode</input>
   </div>
   <div id="overflowDiv" class="mx-auto">
     <div id="chatboxContainer" class="mx-auto">

--- a/src/index.html
+++ b/src/index.html
@@ -9,15 +9,19 @@
 <body id="content">
   <nav class="navbar sticky-top navbar-light bg-light">
     <div class="d-flex flex-row justify-content-between align-items-center col-12">
-      <img src="https://f4.bcbits.com/img/0009711024_10.jpg" width="50" height="50" class="flex-row align-top col-1" id="navImg">
+      <img src="https://f4.bcbits.com/img/0009711024_10.jpg" width="50" height="50" class="flex-row align-top col-2" id="navImg">
       <input class="form-control mr-sm-2 col-5" id="chatInput" type="text" placeholder="Type in here to chat!" aria-label="text">
-      <button class="btn btn-outline-success my-1 my-sm-0 col-1" id="clearChat" type="button">Clear Chat</button>
+      <button class="btn btn-outline-success my-sm-0 col-2" id="clearChat" type="button">Clear Chat</button>
     </div>
   </nav>
   <div class="sizeControl container d-flex justify-content-center align-items-center col-12">
     <input type="checkbox" id="increaseSize" style="font-weight:bold">TextSizeIncrease</input>
     <input type="checkbox" id="darkMode" name="dark_light" onclick="toggleDarkLight" title="Toggle dark/light mode">🌛Dark Mode</input>
   </div>
-  <div id="chatBox" class="container mt-3 d-flex flex-column justify-content-end chatbox overflow-auto"></div>
+  <div id="overflowDiv" class="mx-auto">
+    <div id="chatboxContainer" class="mx-auto">
+      <div id="chatBox" class="container d-flex flex-column justify-content-end chatbox"></div>
+    </div>
+  </div>
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -8,13 +8,13 @@
 </head>
 <body id="content">
   <nav class="navbar sticky-top navbar-light bg-light">
-    <div class="d-flex flex-row justify-content-between col-12">
+    <div class="d-flex flex-row justify-content-between align-items-center col-12">
       <img src="https://f4.bcbits.com/img/0009711024_10.jpg" width="50" height="50" class="flex-row align-top col-1" id="navImg">
       <input class="form-control mr-sm-2 col-5" id="chatInput" type="text" placeholder="Type in here to chat!" aria-label="text">
-      <button class="btn btn-outline-success my-2 my-sm-0 col-1" id="clearChat" type="button">Clear Chat</button>
+      <button class="btn btn-outline-success my-1 my-sm-0 col-1" id="clearChat" type="button">Clear Chat</button>
     </div>
   </nav>
-  <div class="sizeControl container d-flex justify-content-center col-12">
+  <div class="sizeControl container d-flex justify-content-center align-items-center col-12">
     <input type="checkbox" id="increaseSize" style="font-weight:bold">TextSizeIncrease</input>
     <input type="checkbox" id="darkMode" name="dark_light" onclick="toggleDarkLight" title="Toggle dark/light mode">🌛Dark Mode</input>
   </div>

--- a/src/javascripts/components/chatBox/chatBox.js
+++ b/src/javascripts/components/chatBox/chatBox.js
@@ -75,12 +75,10 @@ const newMessageEvent = (e) => {
 
 const editMessage = (e) => {
   e.preventDefault();
-  if ($(e.target).hasClass('editBtn')) {
-    util.handleEditBtn(e);
-  }
+  util.handleEditBtn(e);
 };
 
-const updateMessage = (messageId, messageContents) => {
+const updateMessageArray = (messageId, messageContents) => {
   $.each(messages, (i) => {
     if (messageId === messages[i].messageId) {
       messages[i].messageContent = messageContents;
@@ -91,11 +89,9 @@ const updateMessage = (messageId, messageContents) => {
 const saveMessage = (e) => {
   e.preventDefault();
   const messageId = e.target.parentElement.parentElement.id;
-  const messageContents = $(e.target.parentElement).closest('div').find('.messageContent').html();
-  if ($(e.target).hasClass('saveBtn')) {
-    util.handleSaveBtn(e);
-    updateMessage(messageId, messageContents);
-  }
+  const messageContents = $(e.target).closest('.messageContainer').find('.messageContent').html();
+  util.handleSaveBtn(e);
+  updateMessageArray(messageId, messageContents);
 };
 
 const initializeMessages = () => {

--- a/src/javascripts/components/chatBox/chatBox.js
+++ b/src/javascripts/components/chatBox/chatBox.js
@@ -16,33 +16,45 @@ const getLimitedMessageLength = () => {
   return messagesToPrint;
 };
 
+const scrollPosition = () => {
+  const container = $('#chatboxContainer')[0];
+  const containerHeight = container.clientHeight;
+  const contentHeight = container.scrollHeight;
+  container.scrollTop = contentHeight - containerHeight;
+};
+
 const chatBoxBuilder = () => {
   const messagesToPrint = getLimitedMessageLength();
   let domString = [];
   messagesToPrint.forEach((message) => {
     if (message.userId === 'chatBot') {
       domString += `<div id="${message.messageId}" class="messageContainer d-flex flex-column mr-2">`;
-      domString += `<p class="messageDate">${message.timeStamp}</p>`;
+      // domString += `<p class="messageDate">${message.timeStamp}</p>`;
       domString += '<div class="d-flex flex-row">';
-      domString += '<button class="deleteBtn fas fa-times mx-1" data-dismiss="alert" type="button" aria-label="Delete Message"></button>';
-      domString += '<button class="editBtn fas fa-pencil-alt mx-1 " type="button" aria-label="Edit Message"></button>';
-      domString += '<button class="saveBtn fas fa-save mx-1" style="display: none;" aria-label="Save Message"></button>';
-      domString += `<p class="messageContent messageBubbleIn">${message.messageContent}</p>`;
+      domString += '<div id="messageBtns" class="d-flex flex-row">';
+      domString += '<button class="deleteBtn fas fa-times" data-dismiss="alert" type="button" aria-label="Delete Message"></button>';
+      domString += '<button class="editBtn fas fa-pencil-alt" type="button" aria-label="Edit Message"></button>';
+      domString += '<button class="saveBtn fas fa-save" style="display: none;" aria-label="Save Message"></button>';
+      domString += '</div>';
+      domString += `<p class="messageContent messageBubbleIn msg-cont-left">${message.messageContent}</p>`;
       domString += '</div>';
       domString += '</div>';
     } else {
       domString += `<div id="${message.messageId}" class="messageContainer d-flex flex-column align-items-end text-right ml-2">`;
       domString += `<p class="messageDate">${message.timeStamp}</p>`;
       domString += '<div class="d-flex flex-row">';
-      domString += `<p class="messageContent messageBubbleOut">${message.messageContent}</p>`;
-      domString += '<button class="saveBtn fas fa-save mx-1" style="display: none;" aria-label="Save Message"></button>';
-      domString += '<button class="editBtn fas fa-pencil-alt mx-1" aria-label="Edit Message"></button>';
-      domString += '<button class="deleteBtn fas fa-times mx-1" data-dismiss="alert" aria-label="Delete Message"></button>';
+      domString += `<p class="messageContent messageBubbleOut msg-cont-right">${message.messageContent}</p>`;
+      domString += '<div id="messageBtns" class="d-flex flex-row">';
+      domString += '<button class="saveBtn fas fa-save" style="display: none;" aria-label="Save Message"></button>';
+      domString += '<button class="editBtn fas fa-pencil-alt" aria-label="Edit Message"></button>';
+      domString += '<button class="deleteBtn fas fa-times" data-dismiss="alert" aria-label="Delete Message"></button>';
+      domString += '</div>';
       domString += '</div>';
       domString += '</div>';
     }
   });
   util.printToDom('chatBox', domString);
+  scrollPosition();
 };
 
 const clearMessages = () => {
@@ -81,16 +93,18 @@ const updateMessageArray = (messageId, messageContents) => {
   $.each(messages, (i) => {
     if (messageId === messages[i].messageId) {
       messages[i].messageContent = messageContents;
+      messages[i].timeStamp = moment().format('MMMM D, YYYY h:mm A');
     }
   });
+  chatBoxBuilder();
 };
 
 const saveMessage = (e) => {
   e.preventDefault();
-  const messageId = e.target.parentElement.parentElement.id;
+  const messageId = $(e.target).closest('.messageContainer').attr('id');
   const messageContents = $(e.target).closest('.messageContainer').find('.messageContent').html();
-  util.handleSaveBtn(e);
   updateMessageArray(messageId, messageContents);
+  util.handleSaveBtn(e);
 };
 
 const initializeMessages = () => {

--- a/src/javascripts/components/chatBox/chatBox.js
+++ b/src/javascripts/components/chatBox/chatBox.js
@@ -28,9 +28,9 @@ const chatBoxBuilder = () => {
   let domString = [];
   messagesToPrint.forEach((message) => {
     if (message.userId === 'chatBot') {
-      domString += `<div id="${message.messageId}" class="messageContainer d-flex flex-column mr-2">`;
+      domString += `<div id="${message.messageId}" class="messageContainer d-flex flex-column align-items-start mr-2">`;
       // domString += `<p class="messageDate">${message.timeStamp}</p>`;
-      domString += '<div class="d-flex flex-row">';
+      domString += '<div class="d-flex flex-row messageRow">';
       domString += '<div id="messageBtns" class="d-flex flex-row">';
       domString += '<button class="deleteBtn fas fa-times" data-dismiss="alert" type="button" aria-label="Delete Message"></button>';
       domString += '<button class="editBtn fas fa-pencil-alt" type="button" aria-label="Edit Message"></button>';
@@ -42,7 +42,7 @@ const chatBoxBuilder = () => {
     } else {
       domString += `<div id="${message.messageId}" class="messageContainer d-flex flex-column align-items-end text-right ml-2">`;
       domString += `<p class="messageDate">${message.timeStamp}</p>`;
-      domString += '<div class="d-flex flex-row">';
+      domString += '<div class="d-flex flex-row messageRow">';
       domString += `<p class="messageContent messageBubbleOut msg-cont-right">${message.messageContent}</p>`;
       domString += '<div id="messageBtns" class="d-flex flex-row">';
       domString += '<button class="saveBtn fas fa-save" style="display: none;" aria-label="Save Message"></button>';

--- a/src/javascripts/components/chatBox/chatBox.js
+++ b/src/javascripts/components/chatBox/chatBox.js
@@ -89,6 +89,7 @@ const editMessage = (e) => {
   util.handleEditBtn(e);
 };
 
+
 const updateMessageArray = (messageId, messageContents) => {
   $.each(messages, (i) => {
     if (messageId === messages[i].messageId) {
@@ -99,10 +100,19 @@ const updateMessageArray = (messageId, messageContents) => {
   chatBoxBuilder();
 };
 
+const getText = (element) => {
+  const firstTag = element[0].firstChild.nodeName;
+  const keyTag = new RegExp(firstTag === '#text' ? '<br' : `</${firstTag}`, 'i');
+  const tmp = document.createElement('p');
+  tmp.innerHTML = element[0].innerHTML.replace(/<[^>]+>/g, m => (keyTag.test(m) ? '{ß®}' : '')).replace(/{ß®}$/, '');
+  return tmp.innerText.replace(/{ß®}/g, '\n');
+};
+
 const saveMessage = (e) => {
   e.preventDefault();
   const messageId = $(e.target).closest('.messageContainer').attr('id');
-  const messageContents = $(e.target).closest('.messageContainer').find('.messageContent').html();
+  const messageContentContainer = $(e.target).closest('.messageContainer').find('.messageContent');
+  const messageContents = getText(messageContentContainer);
   updateMessageArray(messageId, messageContents);
   util.handleSaveBtn(e);
 };

--- a/src/javascripts/components/chatBox/chatBox.js
+++ b/src/javascripts/components/chatBox/chatBox.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import moment from 'moment';
 
 import messagesData from '../../helpers/data/messagesData';
@@ -21,23 +22,23 @@ const chatBoxBuilder = () => {
   let domString = [];
   messagesToPrint.forEach((message) => {
     if (message.userId === 'chatBot') {
-      domString += `<div id="${message.messageId}" class="d-flex flex-column mr-2">`;
+      domString += `<div id="${message.messageId}" class="messageContainer d-flex flex-column mr-2">`;
       domString += `<p class="messageDate">${message.timeStamp}</p>`;
       domString += '<div class="d-flex flex-row">';
-      domString += '<button type="button" class="close mx-2" data-dismiss="alert" aria-label="DeleteMessage">';
-      domString += '<span aria-hidden="true">&times;</span>';
-      domString += '</button>';
-      domString += `<p class="message messageBubbleIn">${message.messageContent}</p>`;
+      domString += '<button class="deleteBtn fas fa-times mx-1" data-dismiss="alert" type="button" aria-label="Delete Message"></button>';
+      domString += '<button class="editBtn fas fa-pencil-alt mx-1 " type="button" aria-label="Edit Message"></button>';
+      domString += '<button class="saveBtn fas fa-save mx-1" style="display: none;" aria-label="Save Message"></button>';
+      domString += `<p class="messageContent messageBubbleIn">${message.messageContent}</p>`;
       domString += '</div>';
       domString += '</div>';
     } else {
-      domString += `<div id="${message.messageId}" class="d-flex flex-column align-items-end text-right ml-2">`;
+      domString += `<div id="${message.messageId}" class="messageContainer d-flex flex-column align-items-end text-right ml-2">`;
       domString += `<p class="messageDate">${message.timeStamp}</p>`;
       domString += '<div class="d-flex flex-row">';
-      domString += `<p class="message messageBubbleOut">${message.messageContent}</p>`;
-      domString += '<button type="button" class="close mx-2" data-dismiss="alert" aria-label="Delete Message">';
-      domString += '<span aria-hidden="true">&times;</span>';
-      domString += '</button>';
+      domString += `<p class="messageContent messageBubbleOut">${message.messageContent}</p>`;
+      domString += '<button class="saveBtn fas fa-save mx-1" style="display: none;" aria-label="Save Message"></button>';
+      domString += '<button class="editBtn fas fa-pencil-alt mx-1" aria-label="Edit Message"></button>';
+      domString += '<button class="deleteBtn fas fa-times mx-1" data-dismiss="alert" aria-label="Delete Message"></button>';
       domString += '</div>';
       domString += '</div>';
     }
@@ -72,6 +73,31 @@ const newMessageEvent = (e) => {
   }
 };
 
+const editMessage = (e) => {
+  e.preventDefault();
+  if ($(e.target).hasClass('editBtn')) {
+    util.handleEditBtn(e);
+  }
+};
+
+const updateMessage = (messageId, messageContents) => {
+  $.each(messages, (i) => {
+    if (messageId === messages[i].messageId) {
+      messages[i].messageContent = messageContents;
+    }
+  });
+};
+
+const saveMessage = (e) => {
+  e.preventDefault();
+  const messageId = e.target.parentElement.parentElement.id;
+  const messageContents = $(e.target.parentElement).closest('div').find('.messageContent').html();
+  if ($(e.target).hasClass('saveBtn')) {
+    util.handleSaveBtn(e);
+    updateMessage(messageId, messageContents);
+  }
+};
+
 const initializeMessages = () => {
   messagesData.getMessagesData()
     .then((resp) => {
@@ -82,4 +108,6 @@ const initializeMessages = () => {
     .catch(err => console.error(err));
 };
 
-export default { initializeMessages, newMessageEvent, clearMessages };
+export default {
+  initializeMessages, newMessageEvent, clearMessages, editMessage, saveMessage,
+};

--- a/src/javascripts/components/chatBox/chatBox.scss
+++ b/src/javascripts/components/chatBox/chatBox.scss
@@ -1,3 +1,5 @@
+@import '~@fortawesome/fontawesome-free/css/all.css';
+
 .chatbox {
   width: 50vw;
   height: 85vh;
@@ -7,7 +9,7 @@
   padding: 1rem .5rem;
 };
 
-.message {
+.messageContent {
   margin: 1% 0;
 };
 
@@ -28,3 +30,47 @@
   border-radius: 20px;
   padding: .2rem .5rem;
 };
+
+.deleteBtn:not(:disabled):not(.disabled):hover,
+.deleteBtn:not(:disabled):not(.disabled):focus,
+.editBtn:not(:disabled):not(.disabled):hover,
+.editBtn:not(:disabled):not(.disabled):focus,
+.saveBtn:not(:disabled):not(.disabled):hover,
+.saveBtn:not(:disabled):not(.disabled):focus {
+  opacity: .75;
+}
+
+button.editBtn,
+button.saveBtn,
+button.deleteBtn {
+  padding: 0;
+  background-color: transparent;
+  border: 0;
+  appearance: none;
+  justify-content: center;
+  align-items: center;
+}
+
+deleteBtn,
+editBtn,
+saveBtn {
+  float: right;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1;
+  text-shadow: 0 1px o #fff;
+}
+
+.editBtn .fa-pencil-alt,
+.deleteBtn .fa-times {
+  color: #000;
+  opacity: .5;
+} 
+
+.editBtn .fa-pencil-alt:hover,
+.deleteBtn .fa-times:hover {
+  color: #000;
+  text-decoration: none;
+  opacity: 1;
+  align-items: center;
+}

--- a/src/javascripts/components/chatBox/chatBox.scss
+++ b/src/javascripts/components/chatBox/chatBox.scss
@@ -2,7 +2,7 @@
 
 .chatbox {
   width: 50vw;
-  height: 85vh;
+  height: 80vh;
   background: white;
   border-radius: 25px;
   font-size: .9rem;

--- a/src/javascripts/components/chatBox/chatBox.scss
+++ b/src/javascripts/components/chatBox/chatBox.scss
@@ -1,13 +1,34 @@
 @import '~@fortawesome/fontawesome-free/css/all.css';
 
+#overflowDiv {
+  width: 50vw;
+  height: 85vh;
+  border-radius: 25px;
+  overflow: hidden;
+}
+
+#chatboxContainer {
+  display: flex;
+  justify-content: flex-end;
+  width: 50vw;
+  height: 85vh;
+  border-radius: 25px;
+  overflow: auto;
+  background-color: white;
+}
+
 .chatbox {
   width: 50vw;
-  height: 80vh;
+  margin: 0px;
   background: white;
   border-radius: 25px;
   font-size: .9rem;
   padding: 1rem .5rem;
 };
+
+#chatboxContainer > :first-child {
+  margin-top: auto;
+}
 
 .messageContent {
   margin: 1% 0;
@@ -24,9 +45,20 @@
   padding: .3rem .7rem;
 };
 
+.msg-cont-left.editable {
+  background-color: transparent;
+  box-shadow: inset 0 0 0 2px #e1e1e1, 0 0 1px rgba(0, 0, 0, 0);
+};
+
+.msg-cont-right.editable {
+  background-color: rgba(22, 131, 241, 0.5);
+  color: black;
+  box-shadow: inset 0 0 0 2px #e1e1e1, 0 0 1px rgba(0, 0, 0, 0);
+};
+
 .messageBubbleOut {
   color: white;
-  background-color: #1685F1;
+  background-color: #1685f1;
   border-radius: 20px;
   padding: .2rem .5rem;
 };
@@ -40,10 +72,24 @@
   opacity: .75;
 }
 
+#messageBtns {
+  opacity: 0;
+}
+
+.msg-cont-left {
+  position: relative;
+  left: -25px;
+}
+
+.msg-cont-right {
+  position: relative;
+  right: -25px;
+}
+
 button.editBtn,
 button.saveBtn,
 button.deleteBtn {
-  padding: 0;
+  padding: .1rem;
   background-color: transparent;
   border: 0;
   appearance: none;

--- a/src/javascripts/components/eventListeners.js
+++ b/src/javascripts/components/eventListeners.js
@@ -1,13 +1,13 @@
 import $ from 'jquery';
 
 import chatBox from './chatBox/chatBox';
-
-window.jQuery = $;
-window.$ = $;
+// import util from '../helpers/util';
 
 const eventListeners = () => {
   $('#chatInput').keyup(chatBox.newMessageEvent);
   $('#clearChat').click(chatBox.clearMessages);
+  $('#chatBox').click(chatBox.editMessage);
+  $('#chatBox').click(chatBox.saveMessage);
   $('#increaseSize').click(function increaseSize() {
     let size = parseInt($('#chatBox').css('font-size'), 10);
     if ($(this).is(':checked')) {

--- a/src/javascripts/components/eventListeners.js
+++ b/src/javascripts/components/eventListeners.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import chatBox from './chatBox/chatBox';
 
 const eventListeners = () => {

--- a/src/javascripts/components/eventListeners.js
+++ b/src/javascripts/components/eventListeners.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import chatBox from './chatBox/chatBox';
+import effects from '../helpers/effects';
 
 const eventListeners = () => {
   $('#chatInput').keyup(chatBox.newMessageEvent);
@@ -7,6 +8,8 @@ const eventListeners = () => {
   $('#chatBox').on('click', '.editBtn', chatBox.editMessage);
   $('#chatBox').on('click', '.saveBtn', chatBox.saveMessage);
   $('#chatBox').on('click', '.deleteBtn', chatBox.deleteMessage);
+  $('#chatBox').on('mouseenter', '.messageContainer', effects.messageMouseenter);
+  $('#chatBox').on('mouseleave', '.messageContainer', effects.messageMouseleave);
   $('#increaseSize').click(function increaseSize() {
     let size = parseInt($('#chatBox').css('font-size'), 10);
     if ($(this).is(':checked')) {

--- a/src/javascripts/components/eventListeners.js
+++ b/src/javascripts/components/eventListeners.js
@@ -8,8 +8,8 @@ const eventListeners = () => {
   $('#chatBox').on('click', '.editBtn', chatBox.editMessage);
   $('#chatBox').on('click', '.saveBtn', chatBox.saveMessage);
   $('#chatBox').on('click', '.deleteBtn', chatBox.deleteMessage);
-  $('#chatBox').on('mouseenter', '.messageContainer', effects.messageMouseenter);
-  $('#chatBox').on('mouseleave', '.messageContainer', effects.messageMouseleave);
+  $('#chatBox').on('mouseenter', '.messageRow', effects.messageMouseenter);
+  $('#chatBox').on('mouseleave', '.messageRow', effects.messageMouseleave);
   $('#toggleDark').click(() => {
     $('#content').toggleClass('darkMode');
   });

--- a/src/javascripts/components/eventListeners.js
+++ b/src/javascripts/components/eventListeners.js
@@ -1,13 +1,12 @@
 import $ from 'jquery';
 
 import chatBox from './chatBox/chatBox';
-// import util from '../helpers/util';
 
 const eventListeners = () => {
   $('#chatInput').keyup(chatBox.newMessageEvent);
   $('#clearChat').click(chatBox.clearMessages);
-  $('#chatBox').click(chatBox.editMessage);
-  $('#chatBox').click(chatBox.saveMessage);
+  $('#chatBox').on('click', '.editBtn', chatBox.editMessage);
+  $('#chatBox').on('click', '.saveBtn', chatBox.saveMessage);
   $('#increaseSize').click(function increaseSize() {
     let size = parseInt($('#chatBox').css('font-size'), 10);
     if ($(this).is(':checked')) {

--- a/src/javascripts/helpers/effects.js
+++ b/src/javascripts/helpers/effects.js
@@ -1,0 +1,47 @@
+import $ from 'jquery';
+
+const messageMouseenter = (e) => {
+  e.preventDefault();
+  // const messageId = $(e.target).closest('.messageContainer').attr('id');
+  const messageContentContainer = $(e.target).closest('.messageContainer').find('.messageContent');
+  const messageBtns = $(e.target).closest('.messageContainer').find('#messageBtns');
+  if ((messageContentContainer).hasClass('msg-cont-left')) {
+    $(messageContentContainer).animate({
+      left: '+=25px',
+    });
+    $(messageBtns).animate({
+      opacity: '1',
+    });
+  } else if ((messageContentContainer).hasClass('msg-cont-right')) {
+    $(messageContentContainer).animate({
+      right: '+=25px',
+    });
+    $(messageBtns).animate({
+      opacity: '1',
+    });
+  }
+};
+
+const messageMouseleave = (e) => {
+  e.preventDefault();
+  // const messageId = $(e.target).closest('.messageContainer').attr('id');
+  const messageContentContainer = $(e.target).closest('.messageContainer').find('.messageContent');
+  const messageBtns = $(e.target).closest('.messageContainer').find('#messageBtns');
+  if ((messageContentContainer).hasClass('msg-cont-left')) {
+    $(messageContentContainer).animate({
+      left: '-25px',
+    });
+    $(messageBtns).animate({
+      opacity: '0',
+    });
+  } else if ((messageContentContainer).hasClass('msg-cont-right')) {
+    $(messageContentContainer).animate({
+      right: '-25px',
+    });
+    $(messageBtns).animate({
+      opacity: '0',
+    });
+  }
+};
+
+export default { messageMouseenter, messageMouseleave };

--- a/src/javascripts/helpers/util.js
+++ b/src/javascripts/helpers/util.js
@@ -6,7 +6,7 @@ const printToDom = (divId, textToPrint) => {
 };
 
 const handleEditBtn = (e) => {
-  const messageContainer = $(e.target.parentElement).closest('div').find('.messageContent');
+  const messageContainer = $(e.target).closest('.messageContainer').find('.messageContent');
   const saveBtn = $(e.target.parentElement).closest('div').find('.saveBtn');
   const editBtn = $(e.target.parentElement).closest('div').find('.editBtn');
   $(messageContainer).addClass('editable');
@@ -16,7 +16,7 @@ const handleEditBtn = (e) => {
 };
 
 const handleSaveBtn = (e) => {
-  const messageContainer = $(e.target.parentElement).closest('div').find('.messageContent');
+  const messageContainer = $(e.target).closest('.messageContainer').find('.messageContent');
   const saveBtn = $(e.target.parentElement).closest('div').find('.saveBtn');
   const editBtn = $(e.target.parentElement).closest('div').find('.editBtn');
   $(messageContainer).removeClass('editable');

--- a/src/javascripts/helpers/util.js
+++ b/src/javascripts/helpers/util.js
@@ -1,6 +1,28 @@
+import $ from 'jquery';
+
 const printToDom = (divId, textToPrint) => {
   const selectedDiv = document.getElementById(divId);
   selectedDiv.innerHTML = textToPrint;
 };
 
-export default { printToDom };
+const handleEditBtn = (e) => {
+  const messageContainer = $(e.target.parentElement).closest('div').find('.messageContent');
+  const saveBtn = $(e.target.parentElement).closest('div').find('.saveBtn');
+  const editBtn = $(e.target.parentElement).closest('div').find('.editBtn');
+  $(messageContainer).addClass('editable');
+  $(messageContainer).attr('contenteditable', 'true');
+  $(editBtn).hide();
+  $(saveBtn).show();
+};
+
+const handleSaveBtn = (e) => {
+  const messageContainer = $(e.target.parentElement).closest('div').find('.messageContent');
+  const saveBtn = $(e.target.parentElement).closest('div').find('.saveBtn');
+  const editBtn = $(e.target.parentElement).closest('div').find('.editBtn');
+  $(messageContainer).removeClass('editable');
+  $(messageContainer).removeAttr('contenteditable');
+  $(saveBtn).hide();
+  $(editBtn).show();
+};
+
+export default { printToDom, handleEditBtn, handleSaveBtn };


### PR DESCRIPTION
closes #5 
**When pulling down, run `npm install` so you get font-awesome and moment.js!**

### package.json
- added font-awesome package for edit, save, and delete buttons

### index.html
- removed font-awesome cdn script
- added an `#overflowDiv` around the `#chatBox` to hide the scroll bar on the edges because of the border-radius
- made small visual changes

### chatbox.js
- imported moment
- added @HeathJHMoore's scroll position work-around
- hid messageDate from chatBot messages
- added a `#messageBtn` div to target them for the `.fadeIn()` and `.fadeOut()` events
- added `editMessage` which makes the `messageContent` editable
- added `saveMessage` which makes the `messageContent` uneditable and runs `updateMessageArray`, which updates the global `message` array's `messageContent` and `timeStamp`

### chatbox.scss
- added the weird `:first-child {margin-top: auto};` to make `#chatBox` appear in the bottom of the container on page load
- change what the `messageContent` looks like when it's editable, for both sides of `#chatBox`
- added opacity changes on button hover
- added `messageContent` positioning for both sides of `#chatBox` which are changed on `mouseenter` and `mouseleave`

### eventlisteners.js
- imported effects dir
- added event handlers for the edit and save buttons
- added event handlers for mouseenter and mouseleave for the messages to show and hide the edit, save, and delete buttons

### effects.js
- created `./helpers/effects.js` to handle the `mouseever` and `mouseleave` effects

### util.js
- added the events for the save and edit buttons which essentially hides the one you click and shows the other one.  i feel like these don't *really* fit in this module, but it seemed like the best place for them to go without having to create yet another module.